### PR TITLE
Remove default email notification and explicitly set to aca in task

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: "3.10"
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 . --count --ignore=E402,W503,W504,F541 --max-line-length=100 --show-source --statistics
+        flake8 . --exclude=docs --count --ignore=W503,W504,F541,E203 --max-line-length=100 --show-source --statistics

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 . --exclude=docs --count --ignore=W503,W504,F541,E203 --max-line-length=100 --show-source --statistics
+        flake8 . --exclude=docs --count --ignore=E402,W503,W504,F541,E203 --max-line-length=100 --show-source --statistics

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -41,7 +41,6 @@ def get_opt(args=None):
     parser.add_argument("--email",
                         action='append',
                         dest='emails',
-                        default=['aca_alert@cfa.harvard.edu'],
                         help="Email address for notificaion")
     args = parser.parse_args()
     return args

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -48,7 +48,7 @@ alert      jeanconn@head.cfa.harvard.edu
 <task aca_hi_bgd>
       cron       * * * * *
       check_cron * * * * *
-      exec aca_hi_bgd_update
+      exec aca_hi_bgd_update --email aca\@cfa.harvard.edu
 
       <check>
         <error>


### PR DESCRIPTION
## Description
Remove default email notification and explicitly set to aca in task. 
See Slack "Why is it that we configured the email to slack bridge again?".

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Changes email notification from aca_alert to aca.

## Testing
<!-- If relevant describe any special setup for testing. -->
No testing, code inspection is sufficient.
