### PR TITLE
Add higher threshold for emails and more text in email message

### DIFF
--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -759,7 +759,7 @@ def get_slot_mags(time: CxoTimeLike) -> dict:
         guide_cat[guide_cat["mag"] == -999.00] = 15
 
     # Initialize the slot magnitudes to 15 (faint enough to not have impact)
-    slot_mag = {slot: 15 for slot in range(8)}
+    slot_mag = dict.fromkeys(range(8), 15)
     for slot in range(8):
         if len(guide_cat) == 0:
             continue

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1236,12 +1236,17 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
                 outdir=event_outdir,
             )
             LOGGER.warning(f"HI BGD event in obsid {obsid} {url}")
-            if len(opt.emails) > 0:
+
+            # Add another filter on the data for the emails to only include
+            # events with more than 200 slot seconds.
+            if np.any(obs_events["slot_seconds"] > 200) and len(opt.emails) > 0:
                 send_mail(
                     LOGGER,
                     opt,
                     f"ACA HI BGD event in obsid {obsid}",
-                    f"HI BGD in obsid {obsid} report at {url}",
+                    f"HI BGD in obsid {obsid} report at {url} with "
+                    f"max duration {np.max(obs_events['duration']):.1f}"
+                    f" and max slot seconds {np.max(obs_events['slot_seconds']):.1f}",
                     __file__,
                 )
 


### PR DESCRIPTION
## Description
Add higher threshold for emails (200 slot seconds instead of 60) and more text in email message

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #21 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Local functional testing on my mac isn't configured to send email but prints this out which looks reasonable, and is an email for the only dwell with >= 200 slot seconds in the range I processed.
```
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit
Subject: ACA HI BGD event in obsid 42666
From: jean@head.cfa.harvard.edu
To: jconnelly@cfa.harvard.edu

******************************************
Running /Users/jean/git/aca_hi_bgd/aca_hi_bgd/update_bgd_events.py
acdc version: 4.13.3
Time: Wed Mar 19 11:29:52 2025
User: jean
Machine: flame.local
Processing args:
{'data_root': '/Users/jean/bgddata',
 'emails': ['jconnelly@cfa.harvard.edu'],
 'replot': False,
 'start': '2025:042',
 'stop': '2025:047',
 'web_out': '/Users/jean/bgdweb',
 'web_url': 'file:///Users/jean/bgdweb'}
******************************************

HI BGD in obsid 42666 report at file:///Users/jean/bgdweb/events/2025/dwell_2025:045:06:37:16.132 with max duration 311.6 and max slot seconds 258.3
```