### PR TITLE
Update from maude data

### DIFF
--- a/aca_hi_bgd/plots.py
+++ b/aca_hi_bgd/plots.py
@@ -907,7 +907,7 @@ def plot_events_top(dwell_events):
         go.Bar(x=x, y=hist, name="Events", hovertext=hovertext, hoverinfo="text")
     )
     fig.update_layout(
-        title="Number of ACA HI BGD events per year",
+        title="Number of ACA HI BGD events per year\n(these are one year bins relative to now)",
         yaxis_title="Number of events",
         height=400,
         width=600,

--- a/aca_hi_bgd/task_schedule.cfg
+++ b/aca_hi_bgd/task_schedule.cfg
@@ -48,7 +48,7 @@ alert      aca@cfa.harvard.edu
 <task aca_hi_bgd>
       cron       * * * * *
       check_cron * * * * *
-      exec aca_hi_bgd_update --email aca\@cfa.harvard.edu --data-root $ENV{SKA}/data/aca_hi_bgd_mon --web-out $ENV{SKA}/www/ASPECT/aca_hi_bgd_mon
+      exec aca_hi_bgd_update --email aca\@cfa.harvard.edu --data-root $ENV{SKA}/data/aca_hi_bgd_mon --web-out $ENV{SKA}/www/ASPECT/aca_hi_bgd_mon --maude
 
       <check>
         <error>

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -834,9 +834,21 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple
             Dictionary of metrics for each slot
 
     """
+    start = CxoTime(start)
+    stop = CxoTime(stop)
+
     slot_mag = get_slot_mags(start)
 
     bgd_events = []
+
+    # First, just check for available tccd telemetry
+    _, aacccdpt_stop = fetch.get_time_range("AACCCDPT")
+    aacccdpt_stop = CxoTime(aacccdpt_stop)
+    if aacccdpt_stop < stop:
+        LOGGER.info(
+            f"Skipping dwell {start} to {stop} because no CXC TCCD data after {aacccdpt_stop.date}"
+        )
+        return [], None, {}
 
     try:
         sd_table = get_aca_images(start, stop, source="cxc", bgsub=True)

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -879,8 +879,12 @@ def get_bgd_events_for_manvr(
     slots_metrics = get_slots_metrics(slots_data)
 
     # Check that the image data is complete for the dwell.
-    # This assumes that it is sufficient to check slot 3
-    if (len(slots_data[3]) == 0) or (stop.secs - slots_data[3]["TIME"][-1]) > 60:
+    # This checks that there are images and that they don't end more than 60 seconds
+    # before the dwell itself ends.
+    if all(
+        len(slots_data[ii]) == 0 or (stop.secs - slots_data[ii]["TIME"][-1]) > 60
+        for ii in range(3, 8)
+    ):
         LOGGER.info(f"Cannot process dwell {start}, missing image data")
         return [], None, {}
 

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -421,7 +421,7 @@ def get_manvr_extra_data(start: CxoTimeLike, stop: CxoTimeLike) -> dict:
     # pitch_comp will just work (needs orbitephem not available to just maude source)
     # For the high background monitor we could go back and use AOSARES1 if we
     # wanted to exclude the cxc eng archive, but that seems not needed
-    with fetch.data_source.set("cxc", "maude allow_subset=False"):
+    with fetch.data_source("cxc", "maude allow_subset=False"):
         pitchs = fetch.Msid("pitch_comp", start, stop)
         if len(pitchs.vals) > 0:
             pitch = np.median(pitchs.vals)
@@ -1252,7 +1252,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
 
     stop = min([CxoTime(opt.stop), last_telem_date])
 
-    with fetch.data_source.set("cxc" if not opt.maude else "maude allow_subset=False"):
+    with fetch.data_source("cxc" if not opt.maude else "maude allow_subset=False"):
         with maude_conf.set_temp("timeout", 5):
             new_events, last_proc_time = get_events(
                 start,

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -870,6 +870,13 @@ def get_manvr_events(
         LOGGER.info(f"Failed to get image data for dwell {start}")
         return [], None, {}
 
+    # If there is no IMGSIZE column, let's just add one
+    # IMGTYPE 4 -> 8x8, 1 -> 6x6, 0 -> 4x4
+    if "IMGSIZE" not in sd_table.colnames:
+        sd_table["IMGSIZE"] = np.zeros(len(sd_table), dtype=int)
+        for itype, size in zip([4, 1, 0], [8, 6, 4], strict=True):
+            sd_table["IMGSIZE"][sd_table["IMGTYPE"] == itype] = size
+
     slots_data = {slot: sd_table[sd_table["IMGNUM"] == slot] for slot in range(8)}
     for slot, s_data in slots_data.items():
         mag = slot_mag[slot] if slot in slot_mag else 15

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -549,7 +549,10 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
             stop = aopcadmd.times[np.where(aopcadmd.vals != "NPNT")[0][0]]
 
         dwell_events, dwell_end_time, slot_metrics = get_manvr_events(
-            start, stop, obsid, data_source=data_source,
+            start,
+            stop,
+            obsid,
+            data_source=data_source,
         )
 
         if dwell_end_time is None:
@@ -826,8 +829,9 @@ def get_slots_metrics(slots_data: dict) -> dict:
     return slots_metrics
 
 
-def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int,
-                     data_source="cxc") -> tuple:
+def get_manvr_events(
+    start: CxoTimeLike, stop: CxoTimeLike, obsid: int, data_source="cxc"
+) -> tuple:
     """
     Review a single dwell for high background events.
 
@@ -877,9 +881,7 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int,
 
     # Check that the image data is complete for the dwell.
     # This assumes that it is sufficient to check slot 3
-    if (len(slots_data[3]) == 0) or (
-        stop.secs - slots_data[3]["TIME"][-1]
-    ) > 60:
+    if (len(slots_data[3]) == 0) or (stop.secs - slots_data[3]["TIME"][-1]) > 60:
         LOGGER.info(f"Cannot process dwell {start}, missing image data")
         return [], None, {}
 
@@ -1229,7 +1231,9 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
         # get the end of backorbit data from maude.  Put a retry around this
         # in case the maude server is down.
         with maude_conf.set_temp("timeout", 5):
-            last_telem_date = retry_call(get_last_backorbit_date, [["AACCCDPT", "AOIMAGE0"]], tries=5, delay=5)
+            last_telem_date = retry_call(
+                get_last_backorbit_date, [["AACCCDPT", "AOIMAGE0"]], tries=5, delay=5
+            )
         last_telem_date = CxoTime(last_telem_date)
     else:
         # Just check for available cxc tccd telemetry
@@ -1240,7 +1244,10 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
 
     with maude_conf.set_temp("timeout", 5):
         new_events, last_proc_time = get_events(
-            start, stop=stop, outdir=opt.web_out, data_root=opt.data_root,
+            start,
+            stop=stop,
+            outdir=opt.web_out,
+            data_root=opt.data_root,
             data_source=data_source,
         )
 

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -7,6 +7,7 @@ import agasc
 import numpy as np
 from acdc.common import send_mail
 from astropy.table import Table, vstack
+import astropy.units as u
 from chandra_aca.aca_image import get_aca_images
 from chandra_aca.transform import mag_to_count_rate
 from cheta import fetch
@@ -14,6 +15,9 @@ from cxotime import CxoTime, CxoTimeLike
 from jinja2 import Template
 from kadi import events
 from kadi.commands import get_starcats
+from ska_helpers.retry import retry_call
+from maude.config import conf as maude_conf
+from maude import get_last_backorbit_date
 from ska_helpers.logging import basic_logger
 from ska_helpers.run_info import log_run_info
 from ska_numpy import interpolate
@@ -70,7 +74,12 @@ def get_opt():
         action="append",
         dest="emails",
         default=[],
-        help="Email address for notificaion",
+        help="Email address for notification",
+    )
+    parser.add_argument(
+        "--maude",
+        action="store_true",
+        help="Use maude data source instead of cxc",
     )
     return parser
 
@@ -450,6 +459,7 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
     stop: CxoTimeLike = None,
     outdir: Path = ".",
     data_root: Path = ".",
+    data_source: str = "cxc",
 ) -> tuple:
     """
     Get high background events in a time range.
@@ -463,6 +473,12 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
         Start of Kalman for the maneuvers to check
     stop : str
         Stop of Kalman for the maneuvers to check
+    outdir : Path
+        Output directory for dwell metrics
+    data_root : Path
+        Root directory for data files
+    data_source : str
+        Data source to use, either "cxc" or "maude"
 
     Returns
     -------
@@ -475,7 +491,7 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
     stop = CxoTime(stop)
     LOGGER.info(f"Processing with start: {start} and stop: {stop}")
     manvrs = events.manvrs.filter(
-        kalman_start__gte=start.date, kalman_start__lte=stop.date, n_dwell__gt=0
+        kalman_start__gte=start.date, next_nman_start__lte=stop.date, n_dwell__gt=0
     )
     LOGGER.info(f"Found {len(manvrs)} maneuvers to process")
 
@@ -533,7 +549,7 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
             stop = aopcadmd.times[np.where(aopcadmd.vals != "NPNT")[0][0]]
 
         dwell_events, dwell_end_time, slot_metrics = get_manvr_events(
-            start, stop, obsid
+            start, stop, obsid, data_source=data_source,
         )
 
         if dwell_end_time is None:
@@ -810,7 +826,8 @@ def get_slots_metrics(slots_data: dict) -> dict:
     return slots_metrics
 
 
-def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple:
+def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int,
+                     data_source="cxc") -> tuple:
     """
     Review a single dwell for high background events.
 
@@ -822,6 +839,8 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple
         End of interval to process
     obsid : int
         Observation ID
+    data_source : str
+        Data source to use, either "cxc" or "maude"
 
     Returns
     -------
@@ -841,17 +860,8 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple
 
     bgd_events = []
 
-    # First, just check for available tccd telemetry
-    _, aacccdpt_stop = fetch.get_time_range("AACCCDPT")
-    aacccdpt_stop = CxoTime(aacccdpt_stop)
-    if aacccdpt_stop < stop:
-        LOGGER.info(
-            f"Skipping dwell {start} to {stop} because no CXC TCCD data after {aacccdpt_stop.date}"
-        )
-        return [], None, {}
-
     try:
-        sd_table = get_aca_images(start, stop, source="cxc", bgsub=True)
+        sd_table = get_aca_images(start, stop, source=data_source, bgsub=True)
     except Exception:
         LOGGER.info(f"Failed to get image data for dwell {start}")
         return [], None, {}
@@ -868,7 +878,7 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple
     # Check that the image data is complete for the dwell.
     # This assumes that it is sufficient to check slot 3
     if (len(slots_data[3]) == 0) or (
-        CxoTime(stop).secs - slots_data[3]["TIME"][-1]
+        stop.secs - slots_data[3]["TIME"][-1]
     ) > 60:
         LOGGER.info(f"Cannot process dwell {start}, missing image data")
         return [], None, {}
@@ -879,8 +889,8 @@ def get_manvr_events(start: CxoTimeLike, stop: CxoTimeLike, obsid: int) -> tuple
 
     for event in merged_events:
         event["obsid"] = obsid
-        event["dwell_datestart"] = start
-        event["dwell_datestop"] = CxoTime(stop).date
+        event["dwell_datestart"] = start.date
+        event["dwell_datestop"] = stop.date
         event["datestart"] = CxoTime(event["tstart"]).date
         stats = get_event_stats(event, slots_data)
         for key in stats:
@@ -1155,6 +1165,8 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
     opt = get_opt().parse_args(args)
     log_run_info(LOGGER.info, opt, version=__version__)
 
+    data_source = "cxc" if not opt.maude else "maude"
+
     EVENT_ARCHIVE = Path(opt.data_root) / "bgd_events.dat"
     Path(opt.data_root).mkdir(parents=True, exist_ok=True)
     start = None
@@ -1210,11 +1222,27 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
             ]
         start = CxoTime(opt.start)
     if start is None:
-        start = CxoTime(-7)
+        start = CxoTime.now() - 7 * u.day
 
-    new_events, last_proc_time = get_events(
-        start, stop=opt.stop, outdir=opt.web_out, data_root=opt.data_root
-    )
+    # Figure out what range of data we can actually process
+    if opt.maude is True:
+        # get the end of backorbit data from maude.  Put a retry around this
+        # in case the maude server is down.
+        with maude_conf.set_temp("timeout", 5):
+            last_telem_date = retry_call(get_last_backorbit_date, [["AACCCDPT", "AOIMAGE0"]], tries=5, delay=5)
+        last_telem_date = CxoTime(last_telem_date)
+    else:
+        # Just check for available cxc tccd telemetry
+        _, aacccdpt_stop = fetch.get_time_range("AACCCDPT")
+        last_telem_date = CxoTime(aacccdpt_stop)
+
+    stop = min([CxoTime(opt.stop), last_telem_date])
+
+    with maude_conf.set_temp("timeout", 5):
+        new_events, last_proc_time = get_events(
+            start, stop=stop, outdir=opt.web_out, data_root=opt.data_root,
+            data_source=data_source,
+        )
 
     if len(new_events) > 0:
         new_events = Table(new_events)

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -547,7 +547,7 @@ def get_events(  # noqa: PLR0912, PLR0915 too many statements, too many branches
         if np.any(aopcadmd.vals != "NPNT"):
             stop = aopcadmd.times[np.where(aopcadmd.vals != "NPNT")[0][0]]
 
-        dwell_events, dwell_end_time, slot_metrics = get_manvr_events(
+        dwell_events, dwell_end_time, slot_metrics = get_bgd_events_for_manvr(
             start,
             stop,
             obsid,
@@ -828,7 +828,7 @@ def get_slots_metrics(slots_data: dict) -> dict:
     return slots_metrics
 
 
-def get_manvr_events(
+def get_bgd_events_for_manvr(
     start: CxoTimeLike, stop: CxoTimeLike, obsid: int, data_source="cxc"
 ) -> tuple:
     """

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1230,18 +1230,16 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
         start = CxoTime.now() - 7 * u.day
 
     # Figure out what range of data we can actually process
-    if opt.maude is True:
+    if opt.maude:
         # get the end of backorbit data from maude.  Put a retry around this
         # in case of intermittent failures.
         with maude_conf.set_temp("timeout", 5):
             last_telem_date = retry_call(get_last_backorbit_date, tries=5, delay=5)
-        last_telem_date = CxoTime(last_telem_date)
     else:
         # Just check for available cxc tccd telemetry
-        _, aacccdpt_stop = fetch.get_time_range("AACCCDPT")
-        last_telem_date = CxoTime(aacccdpt_stop)
+        _, last_telem_date = fetch.get_time_range("AACCCDPT")
 
-    stop = min([CxoTime(opt.stop), last_telem_date])
+    stop = min(CxoTime(opt.stop).date, last_telem_date)
 
     with fetch.data_source("cxc" if not opt.maude else "maude allow_subset=False"):
         with maude_conf.set_temp("timeout", 5):

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -45,7 +45,6 @@ GSHEET_USER_URL = f"{url_start}/{DOC_ID}/edit?usp=sharing"
 
 
 LOGGER = basic_logger(__name__, level="INFO")
-fetch.data_source.set("cxc", "maude allow_subset=False")
 
 
 def get_opt():
@@ -79,7 +78,8 @@ def get_opt():
     parser.add_argument(
         "--maude",
         action="store_true",
-        help="Use maude data source instead of cxc",
+        help="Use maude data source instead of cxc"
+        "(cxc still used for orbitephem for pitch_comp)",
     )
     return parser
 
@@ -417,11 +417,16 @@ def get_manvr_extra_data(start: CxoTimeLike, stop: CxoTimeLike) -> dict:
         Dictionary of extra data for the dwell including "pitch" and "notes"
     """
 
-    pitchs = fetch.Msid("DP_PITCH", start, stop)
-    if len(pitchs.vals) > 0:
-        pitch = np.median(pitchs.vals)
-    else:
-        pitch = -999
+    # Explicitly set the fetch data source to the composite cxc/maude set, so that
+    # pitch_comp will just work (needs orbitephem not available to just maude source)
+    # For the high background monitor we could go back and use AOSARES1 if we
+    # wanted to exclude the cxc eng archive, but that seems not needed
+    with fetch.data_source.set("cxc", "maude allow_subset=False"):
+        pitchs = fetch.Msid("pitch_comp", start, stop)
+        if len(pitchs.vals) > 0:
+            pitch = np.median(pitchs.vals)
+        else:
+            pitch = -999
 
     expected_acqs = 0
     guide_cat = get_guide_cat(start)
@@ -1247,14 +1252,15 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
 
     stop = min([CxoTime(opt.stop), last_telem_date])
 
-    with maude_conf.set_temp("timeout", 5):
-        new_events, last_proc_time = get_events(
-            start,
-            stop=stop,
-            outdir=opt.web_out,
-            data_root=opt.data_root,
-            data_source="cxc" if not opt.maude else "maude",
-        )
+    with fetch.data_source.set("cxc" if not opt.maude else "maude allow_subset=False"):
+        with maude_conf.set_temp("timeout", 5):
+            new_events, last_proc_time = get_events(
+                start,
+                stop=stop,
+                outdir=opt.web_out,
+                data_root=opt.data_root,
+                data_source="cxc" if not opt.maude else "maude",
+            )
 
     if len(new_events) > 0:
         new_events = Table(new_events)

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1267,6 +1267,9 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
     bgd_events.sort("datestart")
 
     # Add a null event at the end
+    # If we didn't actually process any dwells, re-use the start time
+    if last_proc_time is None:
+        last_proc_time = start
     bgd_events.add_row()
     bgd_events[-1]["obsid"] = -1
     bgd_events[-1]["dwell_datestart"] = CxoTime(last_proc_time).date

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -4,10 +4,10 @@ from collections.abc import Callable
 from pathlib import Path
 
 import agasc
+import astropy.units as u
 import numpy as np
 from acdc.common import send_mail
 from astropy.table import Table, vstack
-import astropy.units as u
 from chandra_aca.aca_image import get_aca_images
 from chandra_aca.transform import mag_to_count_rate
 from cheta import fetch
@@ -15,10 +15,10 @@ from cxotime import CxoTime, CxoTimeLike
 from jinja2 import Template
 from kadi import events
 from kadi.commands import get_starcats
-from ska_helpers.retry import retry_call
-from maude.config import conf as maude_conf
 from maude import get_last_backorbit_date
+from maude.config import conf as maude_conf
 from ska_helpers.logging import basic_logger
+from ska_helpers.retry import retry_call
 from ska_helpers.run_info import log_run_info
 from ska_numpy import interpolate
 

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1174,8 +1174,6 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
     opt = get_opt().parse_args(args)
     log_run_info(LOGGER.info, opt, version=__version__)
 
-    data_source = "cxc" if not opt.maude else "maude"
-
     EVENT_ARCHIVE = Path(opt.data_root) / "bgd_events.dat"
     Path(opt.data_root).mkdir(parents=True, exist_ok=True)
     start = None
@@ -1236,7 +1234,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
     # Figure out what range of data we can actually process
     if opt.maude is True:
         # get the end of backorbit data from maude.  Put a retry around this
-        # in case the maude server is down.
+        # in case of intermittent failures.
         with maude_conf.set_temp("timeout", 5):
             last_telem_date = retry_call(
                 get_last_backorbit_date, [["AACCCDPT", "AOIMAGE0"]], tries=5, delay=5
@@ -1255,7 +1253,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
             stop=stop,
             outdir=opt.web_out,
             data_root=opt.data_root,
-            data_source=data_source,
+            data_source="cxc" if not opt.maude else "maude",
         )
 
     if len(new_events) > 0:

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -78,8 +78,7 @@ def get_opt():
     parser.add_argument(
         "--maude",
         action="store_true",
-        help="Use maude data source instead of cxc"
-        "(cxc still used for orbitephem for pitch_comp)",
+        help="Use maude data source instead of cxc",
     )
     return parser
 
@@ -417,16 +416,11 @@ def get_manvr_extra_data(start: CxoTimeLike, stop: CxoTimeLike) -> dict:
         Dictionary of extra data for the dwell including "pitch" and "notes"
     """
 
-    # Explicitly set the fetch data source to the composite cxc/maude set, so that
-    # pitch_comp will just work (needs orbitephem not available to just maude source)
-    # For the high background monitor we could go back and use AOSARES1 if we
-    # wanted to exclude the cxc eng archive, but that seems not needed
-    with fetch.data_source("cxc", "maude allow_subset=False"):
-        pitchs = fetch.Msid("pitch_comp", start, stop)
-        if len(pitchs.vals) > 0:
-            pitch = np.median(pitchs.vals)
-        else:
-            pitch = -999
+    pitchs = fetch.Msid("AOSARES1", start, stop)
+    if len(pitchs.vals) > 0:
+        pitch = np.median(pitchs.vals)
+    else:
+        pitch = -999
 
     expected_acqs = 0
     guide_cat = get_guide_cat(start)

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -176,7 +176,7 @@ def exceeds_threshold(slot_data: Table) -> np.ndarray:
     """
     ok = (
         (slot_data["IMGFUNC"] == 1)
-        & (slot_data["IMGSIZE"] != 4)
+        & ((slot_data["IMGSIZE"] == 6) | (slot_data["IMGSIZE"] == 8))
         & (slot_data["AAPIXTLM"] == "ORIG")
     )
     hits = np.zeros(len(slot_data), dtype=bool)
@@ -357,7 +357,7 @@ def get_event_stats(event: dict, slots_data: dict) -> dict:
 
     count_ok = (
         (event_data["IMGFUNC"] == 1)
-        & (event_data["IMGSIZE"] != 4)
+        & ((event_data["IMGSIZE"] == 6) | (event_data["IMGSIZE"] == 8))
         & (event_data["AAPIXTLM"] == "ORIG")
         & (event_data["bgd"] > event_data["threshold"])
     )
@@ -874,13 +874,6 @@ def get_manvr_events(
     except Exception:
         LOGGER.info(f"Failed to get image data for dwell {start}")
         return [], None, {}
-
-    # If there is no IMGSIZE column, let's just add one
-    # IMGTYPE 4 -> 8x8, 1 -> 6x6, 0 -> 4x4
-    if "IMGSIZE" not in sd_table.colnames:
-        sd_table["IMGSIZE"] = np.zeros(len(sd_table), dtype=int)
-        for itype, size in zip([4, 1, 0], [8, 6, 4], strict=True):
-            sd_table["IMGSIZE"][sd_table["IMGTYPE"] == itype] = size
 
     slots_data = {slot: sd_table[sd_table["IMGNUM"] == slot] for slot in range(8)}
     for slot, s_data in slots_data.items():

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1234,9 +1234,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
         # get the end of backorbit data from maude.  Put a retry around this
         # in case of intermittent failures.
         with maude_conf.set_temp("timeout", 5):
-            last_telem_date = retry_call(
-                get_last_backorbit_date, [["AACCCDPT", "AOIMAGE0"]], tries=5, delay=5
-            )
+            last_telem_date = retry_call(get_last_backorbit_date, tries=5, delay=5)
         last_telem_date = CxoTime(last_telem_date)
     else:
         # Just check for available cxc tccd telemetry

--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,5 +1,4 @@
-# Copied originally from pandas. This config requires ruff >= 0.2.
-target-version = "py311"
+target-version = "py312"
 
 # fix = true
 lint.unfixable = []
@@ -31,6 +30,7 @@ lint.extend-select = [
 "ARG001",  # Unused function argument
 "RSE102",  # Unnecessary parentheses on raised exception
 "PERF401",  # Use a list comprehension to create a transformed list
+"S101",  # Use of `assert` detected
 ]
 
 lint.ignore = [
@@ -40,10 +40,13 @@ lint.ignore = [
   "PLR2004", # Magic number
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
+  "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
+  "PLC0415", # `import` should be at the top-level of a file
 ]
 
 extend-exclude = [
   "docs",
+  "build",
 ]
 
 [lint.pycodestyle]
@@ -55,4 +58,5 @@ max-line-length = 100 # E501 reports lines that exceed the length of 100.
 # - D205: Don't worry about test docstrings
 # - ARG001: Unused function argument false positives for some fixtures
 # - E501: Line-too-long
-"**/tests/test_*.py" = ["D205", "ARG001", "E501"]
+# - S101: Do not use assert
+"**/tests/test_*.py" = ["D205", "ARG001", "E501", "S101"]


### PR DESCRIPTION
## Description

Add an option to update from maude data and configure the cron task to use it.

While in the code, fix a tiny bug related to the last processed time.

Requires https://github.com/sot/maude/pull/49

Requires https://github.com/sot/chandra_aca/pull/195

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I just ran a few days back with the cxc data source and maude.  

CXC: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/aca_hi_bgd/pr25/cxc/

MAUDE: https://icxc.cfa.harvard.edu/aspect/test_review_outputs/aca_hi_bgd/pr25/maude

Unfortunately, just now they aren't different!  But in earlier on-the-side testing, indeed with the maude option the tool was able to process up through the last completed dwell (I didn't try to do partial ones).

