### PR TITLE
Fix more data source issues

### DIFF
--- a/aca_hi_bgd/plots.py
+++ b/aca_hi_bgd/plots.py
@@ -14,7 +14,6 @@ from plotly.subplots import make_subplots
 from ska_helpers.logging import basic_logger
 
 LOGGER = basic_logger(__name__, level="INFO")
-fetch.data_source.set("cxc", "maude allow_subset=False")
 
 
 def rebin_data(
@@ -72,6 +71,7 @@ def plot_dwell(  # noqa: PLR0912, PLR0915 too many statements, too many branches
     dwell_start: CxoTimeLike,
     top_events: Table,
     all_events: Table,
+    data_source: str = "cxc",
 ) -> str:
     """
     Generate a plotly plot of backgrounds data and aokalstr over an event.
@@ -93,6 +93,8 @@ def plot_dwell(  # noqa: PLR0912, PLR0915 too many statements, too many branches
         Start time of the dwell.
     events : Table
         Table of events to be plotted.
+    data_source : str
+        Data source to use, either "cxc" or "maude"
 
     Returns
     -------
@@ -103,7 +105,7 @@ def plot_dwell(  # noqa: PLR0912, PLR0915 too many statements, too many branches
     from aca_hi_bgd.update_bgd_events import get_slot_mags
 
     slot_mag = get_slot_mags(dwell_start)
-    sd_table = get_aca_images(start, stop, source="cxc", bgsub=True)
+    sd_table = get_aca_images(start, stop, source=data_source, bgsub=True)
     slots_data = {slot: sd_table[sd_table["IMGNUM"] == slot] for slot in range(8)}
 
     # Does the observation have 6x6 data?
@@ -435,7 +437,9 @@ def add_slot_background_traces(
         )
 
 
-def get_images_for_plot(start: CxoTimeLike, stop: CxoTimeLike) -> tuple:
+def get_images_for_plot(
+    start: CxoTimeLike, stop: CxoTimeLike, data_source: str = "cxc"
+) -> tuple:
     """
     Retrieve and process ACA images for plotting within a specified time range.
 
@@ -450,6 +454,8 @@ def get_images_for_plot(start: CxoTimeLike, stop: CxoTimeLike) -> tuple:
         Start time for the image retrieval.
     stop : CxoTimeLike
         Stop time for the image retrieval.
+    data_source : str
+        Data source to use, either "cxc" or "maude"
 
     Returns
     -------
@@ -467,7 +473,9 @@ def get_images_for_plot(start: CxoTimeLike, stop: CxoTimeLike) -> tuple:
 
     slot_mag = get_slot_mags(start.secs)
 
-    sd_table = get_aca_images(start.secs - 10, stop.secs + 10, source="cxc", bgsub=True)
+    sd_table = get_aca_images(
+        start.secs - 10, stop.secs + 10, source=data_source, bgsub=True
+    )
     slots_data = {slot: sd_table[sd_table["IMGNUM"] == slot] for slot in range(8)}
 
     for slot in range(8):
@@ -528,7 +536,7 @@ def get_images_for_plot(start: CxoTimeLike, stop: CxoTimeLike) -> tuple:
     return times, image_stacks, bgdavgs, outer_mins, imagesizes
 
 
-def plot_images(start: CxoTimeLike, stop: CxoTimeLike) -> str:  # noqa: PLR0915 Too many statements
+def plot_images(start: CxoTimeLike, stop: CxoTimeLike, data_source: str = "cxc") -> str:  # noqa: PLR0915 Too many statements
     """
     Create an animated plot of ACA images over time.
 
@@ -542,6 +550,8 @@ def plot_images(start: CxoTimeLike, stop: CxoTimeLike) -> str:  # noqa: PLR0915 
         Start time for the image retrieval.
     stop = CxoTimeLike
         Stop time for the image retrieval.
+    data_source : str
+        Data source to use, either "cxc" or "maude"
 
     Returns
     -------
@@ -557,7 +567,9 @@ def plot_images(start: CxoTimeLike, stop: CxoTimeLike) -> str:  # noqa: PLR0915 
         stop = start + 300 * u.s
 
     times, image_stacks, bgdavgs, outer_mins, imagesizes = get_images_for_plot(
-        start, stop
+        start,
+        stop,
+        data_source=data_source,
     )
 
     # Parameters

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -919,6 +919,7 @@ def make_dwell_report(
     obs_events: Table,
     outdir: Path = ".",
     redo: bool = True,
+    data_source: str = "cxc",
 ) -> None:
     """
     Make a report for a high background event.
@@ -937,6 +938,8 @@ def make_dwell_report(
         Output directory
     redo : bool
         Redo the report if it already exists
+    data_source : str
+        Data source to use, either "cxc" or "maude"
     """
     if not Path(outdir).exists():
         # Make the directory if it doesn't exist using Path
@@ -952,7 +955,9 @@ def make_dwell_report(
     top_events = []
     for index, e in enumerate(events_limit_5):
         event = dict(zip(e.colnames, e.as_void(), strict=False))
-        event["img_html"] = plot_images(event["tstart"], event["tstop"])
+        event["img_html"] = plot_images(
+            event["tstart"], event["tstop"], data_source=data_source
+        )
         event["index"] = index
         top_events.append(event)
 
@@ -963,6 +968,7 @@ def make_dwell_report(
         dwell_start,
         top_events=top_events,
         all_events=obs_events,
+        data_source=data_source,
     )
 
     LOGGER.info(f"Making report for {outdir}")
@@ -1209,6 +1215,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
                 / f"{year}"
                 / f"dwell_{dwell_start}",
                 redo=True,
+                data_source="cxc" if not opt.maude else "maude",
             )
         make_summary_reports(
             bgd_events[ok], outdir=opt.web_out, data_root=opt.data_root
@@ -1265,13 +1272,18 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
             obsid = obs_events["obsid"][0]
             url = f"{opt.web_url}/events/{year}/dwell_{dwell_start}"
 
-            make_dwell_report(
-                dwell_start,
-                obs_events["dwell_datestop"][0],
-                obsid,
-                obs_events,
-                outdir=event_outdir,
-            )
+            with fetch.data_source(
+                "cxc" if not opt.maude else "maude allow_subset=False"
+            ):
+                with maude_conf.set_temp("timeout", 5):
+                    make_dwell_report(
+                        dwell_start,
+                        obs_events["dwell_datestop"][0],
+                        obsid,
+                        obs_events,
+                        outdir=event_outdir,
+                        data_source="cxc" if not opt.maude else "maude",
+                    )
             LOGGER.warning(f"HI BGD event in obsid {obsid} {url}")
 
             # Add another filter on the data for the emails to only include


### PR DESCRIPTION
## Description

Fix more data source issues.

While testing #26 errors made it clear that #25 is not complete.  It has most of the hooks to have the background data and checks run appropriately from cxc or MAUDE archive, but was failing to fetch image data from MAUDE for recent cases in the parts of the code to make the per-obsid plots.  And it looks like that was just because it wasn't fully implemented or correctly tested.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For functional testing, I just confirmed that for data that *really* isn't available yet in the cxc archive, that the high background plot making succeeds.  I just used
```
python aca_hi_bgd/update_bgd_events.py --maude --start 2025:278 --web-out mynwebout --data-root myndata
```
to write to test directories.  Without these PR changes, the code to make the images failed unable to find the level 0 data in my local mica archive.
