### PR TITLE
Bug and numpy2

### DIFF
--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -49,8 +49,16 @@ LOGGER = basic_logger(__name__, level="INFO")
 
 def get_opt():
     parser = argparse.ArgumentParser(description="High Background event finder")
-    parser.add_argument("--start", help="Start date")
-    parser.add_argument("--stop", help="Stop date")
+    parser.add_argument(
+        "--start",
+        help="Start date.  If not supplied, will use "
+        "the end of the previously processed events.",
+    )
+    parser.add_argument(
+        "--stop",
+        help="Stop date. If not supplied, will use the"
+        "end of available telemetry minus 60 minutes.",
+    )
     parser.add_argument(
         "--data-root",
         default="./data",
@@ -1239,12 +1247,17 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
         # get the end of backorbit data from maude.  Put a retry around this
         # in case of intermittent failures.
         with maude_conf.set_temp("timeout", 5):
-            last_telem_date = retry_call(get_last_backorbit_date, tries=5, delay=5)
+            last_telem_date = retry_call(
+                get_last_backorbit_date, args=["AACCCDPT"], tries=5, delay=5
+            )
     else:
         # Just check for available cxc tccd telemetry
         _, last_telem_date = fetch.get_time_range("AACCCDPT", format="date")
 
-    stop = min(CxoTime(opt.stop).date, last_telem_date)
+    # Set a stop time from the supplied options or use the end of the available telemetry
+    # minus 60 minutes to be safe.  This is to avoid trying to process dwells that are still
+    # in progress or don't have complete data yet.
+    stop = min(CxoTime(opt.stop).date, (CxoTime(last_telem_date) - 60 * u.min).date)
 
     with fetch.data_source("cxc" if not opt.maude else "maude allow_subset=False"):
         with maude_conf.set_temp("timeout", 5):

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1257,7 +1257,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
     # Set a stop time from the supplied options or use the end of the available telemetry
     # minus 60 minutes to be safe.  This is to avoid trying to process dwells that are still
     # in progress or don't have complete data yet.
-    stop = min(CxoTime(opt.stop).date, (CxoTime(last_telem_date) - 60 * u.min).date)
+    stop = min(CxoTime(opt.stop), CxoTime(last_telem_date) - 60 * u.min)
 
     with fetch.data_source("cxc" if not opt.maude else "maude allow_subset=False"):
         with maude_conf.set_temp("timeout", 5):

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -1242,7 +1242,7 @@ def main(args=None):  # noqa: PLR0912, PLR0915 too many branches, too many state
             last_telem_date = retry_call(get_last_backorbit_date, tries=5, delay=5)
     else:
         # Just check for available cxc tccd telemetry
-        _, last_telem_date = fetch.get_time_range("AACCCDPT")
+        _, last_telem_date = fetch.get_time_range("AACCCDPT", format="date")
 
     stop = min(CxoTime(opt.stop).date, last_telem_date)
 

--- a/aca_hi_bgd/update_bgd_events.py
+++ b/aca_hi_bgd/update_bgd_events.py
@@ -777,7 +777,7 @@ def get_slot_mags(time: CxoTimeLike) -> dict:
         if len(guide_slots) != 1:
             continue
         guide_slot = guide_slots[0]
-        if np.in1d(guide_slot["type"], ["BOT", "GUI"]):
+        if np.isin(guide_slot["type"], ["BOT", "GUI"]):
             # Use the full current agasc for these lookups instead of the commanded magnitude
             star = agasc.get_star(guide_slot["id"], agasc_file="agasc*")
             slot_mag[slot] = star["MAG_ACA"]
@@ -1157,7 +1157,7 @@ def significant_events(bg_events: Table) -> np.array:
     # Filter not null obsid, and either >= n_slots  or >= than duration seconds
     # or notes not an empty or whitespace string
     bg_notes = np.array([note.strip() for note in bg_events["notes"]])
-    ok = ~np.in1d(bg_events["obsid"], [0, -1]) & (
+    ok = ~np.isin(bg_events["obsid"], [0, -1]) & (
         (bg_events["n_slots"] >= 5)
         | (bg_events["slot_seconds"] >= 60)
         | (bg_notes != "")


### PR DESCRIPTION
## Description

Update to use isin instead of in1d to remove numpy warnings.
While making edits, fix a tiny date bug.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
The date bug is basically non-impacting as we've switched to using "--maude" in the cron task, but without the quick fix on date one can get 
```
Traceback (most recent call last):
  File "/Users/jean/git/aca_hi_bgd/aca_hi_bgd/update_bgd_events.py", line 1334, in <module>
    main()
    ~~~~^^
  File "/Users/jean/git/aca_hi_bgd/aca_hi_bgd/update_bgd_events.py", line 1247, in main
    stop = min(CxoTime(opt.stop).date, last_telem_date)
numpy._core._exceptions._UFuncNoLoopError: ufunc 'less' did not contain a loop with signature matching types (<class 'numpy.dtypes.Float64DType'>, <class 'numpy.dtypes.StrDType'>) -> None
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
With the date fix this runs without issue using the older 'cxc' mode.
```
(ska3-flight-2026.1rc5) flame:aca_hi_bgd jean$ python aca_hi_bgd/update_bgd_events.py --data-root odata --web-out oweb
2026-02-06 12:40:07,806 log_run_info: ******************************************
2026-02-06 12:40:07,806 log_run_info: Running: /Users/jean/git/aca_hi_bgd/aca_hi_bgd/update_bgd_events.py
2026-02-06 12:40:07,806 log_run_info: Version: 0.4.1.dev2+g81c3368f0
2026-02-06 12:40:07,806 log_run_info: Time: Fri Feb  6 12:40:07 2026
2026-02-06 12:40:07,806 log_run_info: User: jean
2026-02-06 12:40:07,806 log_run_info: Machine: flame.local
2026-02-06 12:40:07,806 log_run_info: Processing args:
2026-02-06 12:40:07,806 log_run_info: {'data_root': 'odata',
2026-02-06 12:40:07,806 log_run_info:  'emails': [],
2026-02-06 12:40:07,806 log_run_info:  'maude': False,
2026-02-06 12:40:07,806 log_run_info:  'replot': False,
2026-02-06 12:40:07,806 log_run_info:  'start': None,
2026-02-06 12:40:07,806 log_run_info:  'stop': None,
2026-02-06 12:40:07,806 log_run_info:  'web_out': 'oweb',
2026-02-06 12:40:07,806 log_run_info:  'web_url': 'https://cxc.harvard.edu/mta/ASPECT/aca_hi_bgd_mon'}
2026-02-06 12:40:07,806 log_run_info: ******************************************
2026-02-06 12:40:07,815 get_events: Processing with start: 2026:030:17:40:07.807 and stop: 2026:036:12:12:09.063
2026-02-06 12:40:07,888 get_events: Found 34 maneuvers to process
2026-02-06 12:40:07,888 get_hi_bgd_notes: Reading google sheet https://docs.google.com/spreadsheets/d/1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw/export?format=csv&id=1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw&gid=524798125
Downloading https://docs.google.com/spreadsheets/d/1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw/export?format=csv&id=1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw&gid=524798125 [Done]
2026-02-06 12:40:08,821 get_events: Processing manvr start=2026:030:19:56:44.774 dur=2178 n_dwell=1 template=normal obsid 31632 kalman_start 2026:030:20:35:09.487
2026-02-06 12:40:12,958 get_events: Processing manvr start=2026:031:00:51:23.975 dur=1631 n_dwell=1 template=normal obsid 30321 kalman_start 2026:031:01:20:26.988
2026-02-06 12:40:14,783 get_events: Processing manvr start=2026:031:13:18:46.704 dur=1551 n_dwell=2 template=nman_dwell obsid 41756 kalman_start 2026:031:13:46:26.691
2026-02-06 12:40:15,136 get_events: Processing manvr start=2026:031:17:09:59.054 dur=1062 n_dwell=1 template=normal obsid 41755 kalman_start 2026:031:17:29:00.392
2026-02-06 12:40:15,448 get_events: Processing manvr start=2026:031:18:22:10.704 dur=1854 n_dwell=1 template=normal obsid 41754 kalman_start 2026:031:18:55:18.693
2026-02-06 12:40:16,532 get_events: Processing manvr start=2026:032:00:37:17.656 dur=1703 n_dwell=1 template=normal obsid 41753 kalman_start 2026:032:01:07:35.494
2026-02-06 12:40:16,846 get_events: Processing manvr start=2026:032:01:53:58.882 dur=1115 n_dwell=1 template=normal obsid 31045 kalman_start 2026:032:02:13:56.594
2026-02-06 12:40:17,522 get_events: Processing manvr start=2026:032:05:41:43.158 dur=1424 n_dwell=1 template=normal obsid 32127 kalman_start 2026:032:06:06:49.395
2026-02-06 12:40:18,068 get_events: Processing manvr start=2026:032:09:04:57.583 dur=2160 n_dwell=1 template=normal obsid 32136 kalman_start 2026:032:09:43:14.096
2026-02-06 12:40:18,841 get_events: Processing manvr start=2026:032:13:38:46.284 dur=1524 n_dwell=1 template=normal obsid 31046 kalman_start 2026:032:14:05:58.597
2026-02-06 12:40:19,460 get_events: Processing manvr start=2026:032:17:28:40.735 dur=2173 n_dwell=1 template=normal obsid 31445 kalman_start 2026:032:18:06:22.398
2026-02-06 12:40:19,859 get_events: Processing manvr start=2026:032:19:49:24.687 dur=2174 n_dwell=1 template=normal obsid 31047 kalman_start 2026:032:20:27:32.999
2026-02-06 12:40:20,428 get_events: Processing manvr start=2026:032:23:33:28.586 dur=3058 n_dwell=1 template=normal obsid 29981 kalman_start 2026:033:00:26:06.100
2026-02-06 12:40:21,196 get_events: Processing manvr start=2026:033:04:38:56.613 dur=1318 n_dwell=1 template=normal obsid 31280 kalman_start 2026:033:05:02:38.801
2026-02-06 12:40:22,059 get_events: Processing manvr start=2026:033:08:37:05.114 dur=2020 n_dwell=1 template=normal obsid 29833 kalman_start 2026:033:09:12:12.002
2026-02-06 12:40:22,883 get_events: Processing manvr start=2026:033:12:18:35.264 dur=2114 n_dwell=1 template=normal obsid 32137 kalman_start 2026:033:12:55:59.503
2026-02-06 12:40:23,537 get_events: Processing manvr start=2026:033:15:44:58.290 dur=2114 n_dwell=1 template=normal obsid 32111 kalman_start 2026:033:16:22:01.003
2026-02-06 12:40:24,128 get_events: Processing manvr start=2026:033:19:14:42.217 dur=2065 n_dwell=1 template=normal obsid 30296 kalman_start 2026:033:19:50:42.404
2026-02-06 12:40:25,076 get_events: Processing manvr start=2026:034:01:26:57.993 dur=1717 n_dwell=1 template=normal obsid 30393 kalman_start 2026:034:01:57:14.806
2026-02-06 12:40:25,625 get_events: Processing manvr start=2026:034:04:47:00.743 dur=589 n_dwell=1 template=normal obsid 41752 kalman_start 2026:034:04:57:47.006
2026-02-06 12:40:26,245 get_events: Processing manvr start=2026:034:08:16:08.794 dur=2372 n_dwell=1 template=normal obsid 41751 kalman_start 2026:034:08:57:38.007
2026-02-06 12:40:26,733 get_events: Processing manvr start=2026:034:11:05:09.121 dur=1231 n_dwell=2 template=nman_dwell obsid 41750 kalman_start 2026:034:11:27:00.608
2026-02-06 12:40:26,990 get_events: Processing manvr start=2026:034:14:34:24.346 dur=1877 n_dwell=1 template=normal obsid 41749 kalman_start 2026:034:15:07:02.609
2026-02-06 12:40:27,245 get_events: Processing manvr start=2026:034:15:32:05.771 dur=2314 n_dwell=1 template=normal obsid 41748 kalman_start 2026:034:16:12:01.709
2026-02-06 12:40:27,514 get_events: Processing manvr start=2026:034:16:38:48.397 dur=2377 n_dwell=1 template=normal obsid 30127 kalman_start 2026:034:17:20:13.509
2026-02-06 12:40:28,207 get_events: Processing manvr start=2026:034:21:26:15.047 dur=2237 n_dwell=1 template=normal obsid 31433 kalman_start 2026:034:22:05:55.611
2026-02-06 12:40:28,840 get_events: Processing manvr start=2026:035:01:11:21.473 dur=2238 n_dwell=1 template=normal obsid 32142 kalman_start 2026:035:01:50:28.211
2026-02-06 12:40:29,576 get_events: Processing manvr start=2026:035:05:46:28.075 dur=1413 n_dwell=1 template=normal obsid 31444 kalman_start 2026:035:06:11:54.812
2026-02-06 12:40:29,974 get_events: Processing manvr start=2026:035:07:54:32.500 dur=2232 n_dwell=1 template=normal obsid 31048 kalman_start 2026:035:08:33:05.413
2026-02-06 12:40:30,594 get_events: Processing manvr start=2026:035:11:56:15.227 dur=240 n_dwell=1 template=normal obsid 31049 kalman_start 2026:035:12:01:22.214
2026-02-06 12:40:31,269 get_events: Processing manvr start=2026:035:15:24:45.352 dur=1468 n_dwell=1 template=normal obsid 30314 kalman_start 2026:035:15:50:50.015
2026-02-06 12:40:32,054 get_events: Processing manvr start=2026:035:20:37:03.378 dur=1422 n_dwell=1 template=normal obsid 31050 kalman_start 2026:035:21:02:17.816
2026-02-06 12:40:32,640 get_events: Processing manvr start=2026:036:00:08:34.929 dur=1567 n_dwell=1 template=normal obsid 32138 kalman_start 2026:036:00:36:02.617
2026-02-06 12:40:33,269 get_events: Processing manvr start=2026:036:03:25:52.655 dur=2012 n_dwell=1 template=normal obsid 30232 kalman_start 2026:036:04:01:35.418
2026-02-06 12:40:37,701 make_dwell_report: Making report for oweb/events/2026/dwell_2026:031:18:55:18.693
2026-02-06 12:40:37,704 main: HI BGD event in obsid 41754 https://cxc.harvard.edu/mta/ASPECT/aca_hi_bgd_mon/events/2026/dwell_2026:031:18:55:18.693
2026-02-06 12:40:37,715 get_hi_bgd_notes: Reading google sheet https://docs.google.com/spreadsheets/d/1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw/export?format=csv&id=1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw&gid=524798125
Downloading https://docs.google.com/spreadsheets/d/1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw/export?format=csv&id=1GoYBTIQAv0qq2vh3jYxHBYHfEq2I8LVGMiScDX7OFvw&gid=524798125 [Done]
```
